### PR TITLE
Array scope: use array in selector

### DIFF
--- a/lib/protobuf/mongoid/scope.rb
+++ b/lib/protobuf/mongoid/scope.rb
@@ -102,7 +102,8 @@ module Protobuf
             next unless proto.respond_to_and_has_and_present?(field)
 
             search_values = parse_search_values(proto, field)
-            search_relation = search_relation.__send__(scope_name, *search_values)
+            search_relation = search_relation.__send__(scope_name, *search_values)            
+            search_relation.selector[field] = { "$in" => search_values } if search_values.class == Array
           end
 
           search_relation


### PR DESCRIPTION
When an array is given for a field search, we want to search for all records whose field value is _any_ of the given array's field values

In other words, when I search on `id = [1, 2, 3]`, I want to find all records with an id of 1, 2, or 3 (NOT any record whose id is `[1, 2, 3]`)